### PR TITLE
docs(plan): add HYBRID-PLUS v1.2

### DIFF
--- a/docs/PLAN_HYBRID_PLUS_v1.2.md
+++ b/docs/PLAN_HYBRID_PLUS_v1.2.md
@@ -1,0 +1,76 @@
+# Action Plan
+
+## 1 Commit the Plan (`PLAN_HYBRID_PLUS_v1.2.md`)
+
+| Step | Command / Action | Success Signal |
+| --- | --- | --- |
+| 1 | `git switch -c plan/v1.2` | new branch, clean tree |
+| 2 | Add the plan text under `docs/PLAN_HYBRID_PLUS_v1.2.md` | file present |
+| 3 | `git add docs/PLAN_HYBRID_PLUS_v1.2.md` | staged |
+| 4 | `git commit -m "docs(plan): add HYBRID-PLUS v1.2"` | commit created |
+| 5 | `git push -u origin plan/v1.2` | branch on GitHub |
+| 6 | Open a **draft** PR “HYBRID-PLUS v1.2 – action plan” and assign reviewers | diff shows *only* the new MD |
+
+---
+
+## 2 Regenerate Issues & Project Board
+
+| Step | Action | Success Signal |
+| --- | --- | --- |
+| 1 | `pnpm install --frozen-lockfile` (or `npm ci`) | clean deps |
+| 2 | `node scripts/gen-issues.js --update --plan docs/PLAN_HYBRID_PLUS_v1.2.md` | console: “Created/Updated N issues” |
+| 3 | `git add .github && git commit -m "chore(issues): sync from v1.2"git push` | labels/milestones committed |
+| 4 | Project board shows every card (**P2-T1**, **P2-T2**, …) with correct `depends:` links | visual check |
+
+---
+
+## 3 Inject the Sentry Secret Stub (CI6-0)
+
+| Step | Action | Success Signal |
+| --- | --- | --- |
+| 1 | `git switch -c ci/secret-stub-sentry` |  |
+| 2 | GitHub → Settings → Secrets → Actions → add `SENTRY_DSN` = `""` |  |
+| 3 | Update workflow env: `env: { SENTRY_DSN: ${{ secrets.SENTRY_DSN }} }` | `act -j <job>` passes |
+| 4 | Commit, push, PR | CI green < 1 min |
+
+> Quick check: workflow log prints a blank line for echo $SENTRY_DSN.
+> 
+
+---
+
+## 4 Implement **P0-T1** (compile-only gate)
+
+| Micro-task | Command / Edit | Guardrail |
+| --- | --- | --- |
+| 0 | `git switch -c p0-t1/compile-gate` |  |
+| 1 | `package.json` ➜ `"scripts": { "compile": "tsc --noEmit" }` |  |
+| 2 | Root `tsconfig.json` with `"strict": true`, `"skipLibCheck": true` |  |
+| 3 | `.github/workflows/compile.yml` → single step `pnpm run compile` |  |
+| 4 | `pnpm run compile` locally → **0 errors** |  |
+| 5 | Push + link PR to Issue **P0-T1** |  |
+| 6 | CI ≤ 30 s on cache hit |  |
+| 7 | Merge via squash after review |  |
+
+> Failure test: create a deliberate type error on a temp branch → CI must fail.
+> 
+
+---
+
+### FAQ (concise)
+
+| Q | A |
+| --- | --- |
+| Merge plan straight to `main`? | No—keep draft PR until ≥ 1 review. |
+| CI creeping past 12 min? | Batch lint + unit + axe + size-limit in one Node run; cache pnpm. |
+| When to use real Sentry DSN? | Right before **Phase 5 (Release)**; stub suffices now. |
+
+---
+
+## Green-light
+
+Once the boxes below are ticked, you’re unblocked for the rest of Phase 0:
+
+- [ ]  Plan file merged
+- [ ]  Issues / board regenerated
+- [ ]  Sentry stub branch merged
+- [ ]  **P0-T1** compile gate on `main` and green


### PR DESCRIPTION
# HYBRID-PLUS v1.2 — Action-Plan PR  🚦 (Draft)

> **TL;DR**  
> Adds the _single-source_ execution blueprint for the hardening pass.  
> **No code or config yet — only `docs/PLAN_HYBRID_PLUS_v1.2.md`.**

---

## 1 Why this matters
* Establishes the **authoritative backlog** (atomic ≤ 1 h tasks, DAG-typed deps).  
* Unblocks Phase 0 by defining gates, success signals, and review cadence.  
* Prevents drift: all further branches reference task IDs from this plan.

## 2 What’s inside
| Section | Purpose |
|---------|---------|
| **0 Legend** | Serial/⚡ flags, stretch buffer logic |
| **1 Principles** | Atomic tasks, WIP limit, 5 % buffer |
| **2 High-Level Flow** | Wallet → Contracts → Tests → CI/CD → Observability (with parallel tracks for Security, UI, Docs) |
| **3 Backlog** | Phase-scoped tasks (P2-T1 …) with ETA, labels, `depends:` |
| **Risk Matrix (R1–R7)** | Ownership + mitigations |
| **CI6-0 note** | Sentry stub strategy |

_No other files touched; diff is one new Markdown file._

## 3 Acceptance Criteria
* [ ] File path: `docs/PLAN_HYBRID_PLUS_v1.2.md`
* [ ] Passes spell-check & Markdown lint (`npm run lint:docs`)
* [ ] Mermaid diagram renders in GitHub preview
* [ ] Reviewers sign off on:  
  * Task granularity (≤ 1 h)  
  * Dependencies correctness (no dead-locks)  
  * Risk ownership (DRIs assigned)

## 4 How to review quickly
1. **Scan the mermaid flow** — look for missing edges or cycles.  
2. Pick any random task, trace its `depends:` chain; confirm ETA sanity.  
3. Glance at risk matrix: does your area have an owner?  
4. Approve _only_ if the plan is internally coherent; nit all doc issues here, not in later code PRs.

## 5 Next steps after merge
1. **Regenerate issues & board** (`scripts/gen-issues.js`)  
2. Create `ci/secret-stub-sentry` branch → inject blank DSN  
3. Implement **P0-T1** compile-only gate  
_All subsequent branches will reference task IDs from this plan._

---

### Meta
|   |   |
|---|---|
| **Ticket / Epic** | — |
| **Docs preview** | `/docs/PLAN_HYBRID_PLUS_v1.2.md` |
| **Reviewers** | @alice-sec, @bob-devops, @carol-frontend |
| **Labels** | `type:docs`, `scope:plan`, `v1.2` |

> _“Trust, but verify.”_ Please poke holes wherever you see them.